### PR TITLE
ビルド可能なnode.js&npmを特定する

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 
 Slack上でPlantUMLの記述を行えば画像を返してくれるボット。
 
+## Prerequisite
+
+以下の環境下にて、テスト・ビルドが可能を確認している。
+
+- node.js: `10.24.1`
+- npm: `6.14.17`
+
 ## Usage
 
 ### npm build & node run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-plantuml-bot",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/main/plantuml/zip/OriginalZip.ts
+++ b/src/main/plantuml/zip/OriginalZip.ts
@@ -522,9 +522,7 @@ export default class OriginalZip {
 
         for (let bits = 0; bits <= Constant.MAX_BITS; bits++)
             this.bl_count[bits] = 0;
-        let n = 0;
-
-        for (n = 0; n <= 287; n++) {
+        for (let n = 0; n < this.static_ltree.length; n++) {
             let dlValue = 8;
             if (n <= 143) dlValue = 8
             else if (n <= 255) dlValue = 9
@@ -542,9 +540,9 @@ export default class OriginalZip {
         this.gen_codes(this.static_ltree, Constant.L_CODES + 1);
 
         /* The static distance tree is trivial: */
-        for (n = 0; n < Constant.D_CODES; n++) {
-            this.static_dtree[n].dl = 5;
-            this.static_dtree[n].fc = this.bi_reverse(n, 5);
+        for (let i = 0; i < Constant.D_CODES; i++) {
+            this.static_dtree[i].dl = 5;
+            this.static_dtree[i].fc = this.bi_reverse(i, 5);
         }
 
         // Initialize the first block of the first file:

--- a/src/main/plantuml/zip/OriginalZip.ts
+++ b/src/main/plantuml/zip/OriginalZip.ts
@@ -523,10 +523,21 @@ export default class OriginalZip {
         for (let bits = 0; bits <= Constant.MAX_BITS; bits++)
             this.bl_count[bits] = 0;
         let n = 0;
-        while (n <= 143) { this.static_ltree[n++].dl = 8; this.bl_count[8]++; }
-        while (n <= 255) { this.static_ltree[n++].dl = 9; this.bl_count[9]++; }
-        while (n <= 279) { this.static_ltree[n++].dl = 7; this.bl_count[7]++; }
-        while (n <= 287) { this.static_ltree[n++].dl = 8; this.bl_count[8]++; }
+
+        for (n = 0; n <= 287; n++) {
+            let dlValue = 8;
+            if (n <= 143) dlValue = 8
+            else if (n <= 255) dlValue = 9
+            else if (n <= 279) dlValue = 7;
+        
+            this.static_ltree[n].dl = dlValue;
+            this.bl_count[dlValue]++;
+        }
+        // // 上は下のルーチンを書き換えたもの TODO 安定したら下を消す     
+        // while (n <= 143) { this.static_ltree[n++].dl = 8; this.bl_count[8]++; }
+        // while (n <= 255) { this.static_ltree[n++].dl = 9; this.bl_count[9]++; }
+        // while (n <= 279) { this.static_ltree[n++].dl = 7; this.bl_count[7]++; }
+        // while (n <= 287) { this.static_ltree[n++].dl = 8; this.bl_count[8]++; }
 
         this.gen_codes(this.static_ltree, Constant.L_CODES + 1);
 

--- a/src/main/plantuml/zip/OriginalZip.ts
+++ b/src/main/plantuml/zip/OriginalZip.ts
@@ -524,9 +524,10 @@ export default class OriginalZip {
             this.bl_count[bits] = 0;
         for (let n = 0; n < this.static_ltree.length; n++) {
             let dlValue = 8;
-            if (n <= 143) dlValue = 8
-            else if (n <= 255) dlValue = 9
-            else if (n <= 279) dlValue = 7;
+            if (n > 143) {
+                if (n <= 255) dlValue = 9
+                else if (n <= 279) dlValue = 7;
+            }
         
             this.static_ltree[n].dl = dlValue;
             this.bl_count[dlValue]++;


### PR DESCRIPTION
「以前動いていた状態」のnode.js & npmがわからないため、稼働確認を行い、`README.md` に記載。

## その他

- 今後、動かなくなる可能性が在る箇所をリファクタリング
- CIは別の理由でコケるが、マージする

## 課題

`package-lock.json` を「できるだけ維持したまま」でしか動かない。

危ういバランスのため「package-lock.jsonを削除しても(package.jsonだけで `npm install` し直しても)動く」状態に最新化したい。